### PR TITLE
Fix up phpunit config

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,15 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="tests/PHPUnit/bootstrap.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.1/phpunit.xsd" cacheDirectory=".phpunit.cache">
-  <!-- <coverage>
-    <report>
-      <clover outputFile="clover.xml"/>
-    </report>
-  </coverage> -->
+<phpunit
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        bootstrap="vendor/autoload.php"
+        xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.1/phpunit.xsd"
+        cacheDirectory=".phpunit.cache">
   <testsuites>
     <testsuite name="Library">
       <directory>tests/PHPUnit</directory>
     </testsuite>
   </testsuites>
-  <logging/>
-  <source/>
+
+  <source>
+    <include>
+      <directory>src</directory>
+    </include>
+  </source>
 </phpunit>

--- a/tests/PHPUnit/FlagsTest.php
+++ b/tests/PHPUnit/FlagsTest.php
@@ -1,7 +1,5 @@
 <?php
 
-require_once "vendor/autoload.php";
-
 class user {
 	public function __construct(
 		public readonly string $name,


### PR DESCRIPTION
I know you were having some trouble with the phpunit config. This'll let it work with coverage.

```bash
$ XDEBUG_MODE=coverage ./vendor/bin/phpunit --coverage-text             
PHPUnit 11.1.3 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.2.16 with Xdebug 3.2.1
Configuration: /Users/jdonat/TmpProjects/flags/phpunit.xml

...                                                                 3 / 3 (100%)

Time: 00:00.033, Memory: 10.00 MB

OK (3 tests, 20 assertions)


Code Coverage Report:
  2024-05-16 22:06:11

 Summary:
  Classes:  0.00% (0/3)
  Methods:  9.09% (1/11)
  Lines:   40.68% (48/118)

Flags\Flags
  Methods:  16.67% ( 1/ 6)   Lines:  44.86% ( 48/107)
```